### PR TITLE
Fixing the integration test 7-1: toggle between xywh and inset mode.

### DIFF
--- a/cypress/integration/7-1-layer_dimensions_spec.coffee
+++ b/cypress/integration/7-1-layer_dimensions_spec.coffee
@@ -58,10 +58,10 @@ describe "Layer Dimensions", ->
       cy.get("#dim-b").invoke("val").should("eq", "5.0")
       cy.get("#dim-l").invoke("val").should("eq", "5.0")
       # set them all to 10
-      cy.get("#dim-t").clear().type("10")
-      cy.get("#dim-r").clear().type("10")
-      cy.get("#dim-b").clear().type("10")
-      cy.get("#dim-l").clear().type("10")
+      cy.get("#dim-t").clear().type("10.0")
+      cy.get("#dim-r").clear().type("10.0")
+      cy.get("#dim-b").clear().type("10.0")
+      cy.get("#dim-l").clear().type("10.0")
       # click xywh
       cy.contains("XYWH").click()
       # see the x/y/w/h percent values


### PR DESCRIPTION
Fixing the integration test 7-1 toggle between xywh and inset mode. This test was failing all the time when running npm test. Looking at the screenshot, it seems as the change to 10 (instead of 10.0 which is what is changed when you do it manually) was not taking effect. However, it seems more likely that it was a test framework issue, since there is no human way to reproduce the issue when doing it by hand on the website (even changing it very fast to a non decimal number and toggling between inset and xywh).