### PR TITLE
Fix component size widget not displaying the preexisting selected size. Added integration test for it

### DIFF
--- a/cypress/fixtures/components.json
+++ b/cypress/fixtures/components.json
@@ -10,12 +10,14 @@
   "instructionBook": {
     "id": "instructionBook",
     "title": "Instruction Book",
-    "quantityProperty": null
+    "quantityProperty": null,
+    "templateId": "basicCard"
   },
   "pointCubes": {
     "id": "pointCubes",
     "title": "Point Cubes",
-    "quantityProperty": null
+    "quantityProperty": null,
+    "templateId": "basicTile"
   },
   "carcassonneTiles": {
     "id": "carcassonneTiles",

--- a/cypress/fixtures/templates.json
+++ b/cypress/fixtures/templates.json
@@ -4,7 +4,10 @@
     "layerIds": [],
     "size": {
       "w": 2.5,
-      "h": 3.5
+      "h": 3.5,
+      "paperMode": "standard",
+      "paperFormat": "poker",
+      "paperOrientation": "landscape"
     }
   },
   "basicTile": {
@@ -12,7 +15,8 @@
     "layerIds": [],
     "size": {
       "w": 1.5,
-      "h": 1.5
+      "h": 1.5,
+      "paperMode": "custom"
     }
   },
   "loveLetter": {
@@ -20,7 +24,10 @@
     "layerIds": [],
     "size": {
       "w": 2.5,
-      "h": 3.5
+      "h": 3.5,
+      "paperMode": "standard",
+      "paperFormat": "poker",
+      "paperOrientation": "landscape"
     }
   }
 }

--- a/cypress/integration/4-game_editor_page_spec.coffee
+++ b/cypress/integration/4-game_editor_page_spec.coffee
@@ -79,6 +79,20 @@ describe "Game Editor page", ->
 
       cy.contains("Instruction Manual")
 
+    it "displays correctly the size settings of a custom size component", ->
+      cy.contains("Point Cubes")
+        .click()
+
+      cy.get('.component.active')
+        .contains("Edit")
+        .click()
+
+      cy.get('.paper-width input').should('have.value', '1.5')
+      cy.get('.paper-height input').should('have.value', '1.5')
+      cy.get('.component-form')
+        .contains("Done")
+        .click()
+
     it "lets me delete a component", ->
       cy.contains("Instruction Book")
         .click()

--- a/lib/components/sitewide/TitleBar.vue
+++ b/lib/components/sitewide/TitleBar.vue
@@ -4,7 +4,7 @@ v-toolbar(app)
     router-link(:to="{ name: homeLink }") Paperize.io
 
     v-tooltip
-      span.caption(slot="activator")= " ver.A7.0.1"
+      span.caption(slot="activator")= " ver.A7.0.2"
       | Alpha 7 "Obedient Consumer " {{ gitSha }}
 
   v-spacer

--- a/lib/components/template/TemplateSizeEditor.vue
+++ b/lib/components/template/TemplateSizeEditor.vue
@@ -97,11 +97,12 @@ fieldset.fieldset
       updatePageDimensions() {
         if(this.paperFormat.length == 0) { return }
 
-        let format = find(componentOptions, { value: this.paperFormat })
-          , width = format.width
-          , height = format.height
-          , smallerDimension = Math.min(width, height)
-          , largerDimension = Math.max(width, height)
+        const
+          format = find(componentOptions, { value: this.paperFormat }),
+          width = format.width,
+          height = format.height,
+          smallerDimension = Math.min(width, height),
+          largerDimension = Math.max(width, height)
 
         let size = {
           paperFormat: this.paperFormat,

--- a/lib/components/template/TemplateSizeEditor.vue
+++ b/lib/components/template/TemplateSizeEditor.vue
@@ -3,7 +3,7 @@ fieldset.fieldset
   legend
     strong Component Size
 
-  v-btn-toggle(v-model="paperMode" @change="setPaperMode")
+  v-btn-toggle(v-model="paperMode" @change="paperModeChanged")
     v-btn(flat value="standard") Standard
     v-btn(flat value="custom") Custom
 
@@ -82,8 +82,7 @@ fieldset.fieldset
         this.$store.commit("updateTemplate", payload)
       }, 200),
 
-      setPaperMode(mode) {
-        this.paperMode = mode
+      paperModeChanged() {
         if(this.paperMode == "standard") {
           this.paperFormat = "poker"
           this.paperOrientation = "portrait"

--- a/lib/components/template/TemplateSizeEditor.vue
+++ b/lib/components/template/TemplateSizeEditor.vue
@@ -25,8 +25,8 @@ fieldset.fieldset
 </template>
 
 <script>
-  import { debounce, isString, find } from 'lodash'
-  import { mapMutations } from 'vuex'
+  import { isString, find } from 'lodash'
+  import { mapActions } from 'vuex'
 
   const componentOptions = [
     { value: 'poker', name: 'Poker-sized Cards',
@@ -70,7 +70,7 @@ fieldset.fieldset
         set(newWidth) {
           if(isString(newWidth) || newWidth < 0) { newWidth = 0 }
           const newSize = { ...this.template.size, w: newWidth  }
-          this.updateTemplate({ ...this.template, size: newSize })
+          this.patchTemplate({ ...this.template, size: newSize })
         }
       },
 
@@ -79,15 +79,13 @@ fieldset.fieldset
         set(newHeight) {
           if(isString(newHeight) || newHeight < 0) { newHeight = 0 }
           const newSize = { ...this.template.size, h: newHeight }
-          this.updateTemplate({ ...this.template, size: newSize })
+          this.patchTemplate({ ...this.template, size: newSize })
         }
       }
     },
 
     methods: {
-      updateTemplate: debounce(function(payload) {
-        this.$store.commit("updateTemplate", payload)
-      }, 200),
+      ...mapActions(["patchTemplate"]),
 
       paperModeChanged() {
         if(this.paperMode == "standard") {

--- a/lib/components/template/TemplateSizeEditor.vue
+++ b/lib/components/template/TemplateSizeEditor.vue
@@ -3,7 +3,7 @@ fieldset.fieldset
   legend
     strong Component Size
 
-  v-btn-toggle(v-model="paperMode")
+  v-btn-toggle(v-model="paperMode" @change="setPaperMode")
     v-btn(flat value="standard") Standard
     v-btn(flat value="custom") Custom
 
@@ -51,9 +51,9 @@ fieldset.fieldset
       return {
         componentOptions,
         orientationOptions,
-        paperMode: 'standard',
-        paperFormat: '',
-        paperOrientation: 'portrait',
+        paperMode: this.template.size.paperMode || "standard",
+        paperFormat: this.template.size.paperFormat || "poker",
+        paperOrientation: this.template.size.paperOrientation || "landscape",
       }
     },
 
@@ -84,10 +84,13 @@ fieldset.fieldset
 
       setPaperMode(mode) {
         this.paperMode = mode
-
-        if(this.paperMode != "standard") {
-          this.paperFormat = ""
+        if(this.paperMode == "standard") {
+          this.paperFormat = "poker"
           this.paperOrientation = "portrait"
+          this.updatePageDimensions()
+        } else {
+          const newSize = { h: this.template.size.h, w: this.template.size.w, paperMode: mode }
+          this.updateTemplate({ ...this.template, size: newSize })
         }
       },
 
@@ -100,24 +103,27 @@ fieldset.fieldset
           , smallerDimension = Math.min(width, height)
           , largerDimension = Math.max(width, height)
 
-        if(this.paperOrientation == 'portrait') {
-          this.updateTemplate({
-            ...this.template,
-            size: {
-              w: smallerDimension,
-              h: largerDimension
-            }
-          })
-
-        } else if(this.paperOrientation == 'landscape') {
-          this.updateTemplate({
-            ...this.template,
-            size: {
-              w: largerDimension,
-              h: smallerDimension
-            }
-          })
+        let size = {
+          paperFormat: this.paperFormat,
+          paperMode: this.paperMode,
+          paperOrientation: this.paperOrientation
         }
+
+        if(this.paperOrientation == 'portrait') {
+          size = {...size,
+            w: smallerDimension,
+            h: largerDimension
+          }
+        } else if(this.paperOrientation == 'landscape') {
+          size = {...size,
+            w: largerDimension,
+            h: smallerDimension,
+          }
+        }
+        this.updateTemplate({
+          ...this.template,
+          size
+        })
       }
     }
   }

--- a/lib/components/template/TemplateSizeEditor.vue
+++ b/lib/components/template/TemplateSizeEditor.vue
@@ -95,8 +95,12 @@ fieldset.fieldset
           this.paperOrientation = "portrait"
           this.updatePageDimensions()
         } else {
-          const newSize = { h: this.template.size.h, w: this.template.size.w, paperMode: mode }
-          this.updateTemplate({ ...this.template, size: newSize })
+          const size = {
+            h: this.template.size.h,
+            w: this.template.size.w,
+            paperMode: this.paperMode
+          }
+          this.patchTemplate({ ...this.template, size })
         }
       },
 
@@ -127,10 +131,8 @@ fieldset.fieldset
             h: smallerDimension,
           }
         }
-        this.updateTemplate({
-          ...this.template,
-          size
-        })
+
+        this.patchTemplate({ ...this.template, size })
       }
     }
   }

--- a/lib/components/template/TemplateSizeEditor.vue
+++ b/lib/components/template/TemplateSizeEditor.vue
@@ -45,15 +45,22 @@ fieldset.fieldset
   ]
 
   export default {
-    props: ["template"],
+    props: {
+      template: {
+        type: Object,
+        required: true
+      }
+    },
 
     data() {
+      const size = this.template.size || {} // make sure we have defaults
+
       return {
         componentOptions,
         orientationOptions,
-        paperMode: this.template.size.paperMode || "standard",
-        paperFormat: this.template.size.paperFormat || "poker",
-        paperOrientation: this.template.size.paperOrientation || "landscape",
+        paperMode: size.paperMode || "standard",
+        paperFormat: size.paperFormat || "poker",
+        paperOrientation: size.paperOrientation || "landscape",
       }
     },
 

--- a/lib/store/templates.js
+++ b/lib/store/templates.js
@@ -17,7 +17,10 @@ const TemplateModel = {
       layerIds: [],
       size: {
         w: 2.5,
-        h: 3.5
+        h: 3.5,
+        paperMode: "standard",
+        paperFormat: "poker",
+        paperOrientation: "landscape"
       }
     }
   },


### PR DESCRIPTION
Fix component size widget not displaying the preexisting selected size. Basically we now store paper mode, orientation and such in the database, so we can reconstruct the user settings when opening the component again. Added integration test for it. Also, fixed some integration data that didn't have proper template. I submitted this through the fork just because I already had started and didn't want to have to start again or spend much time on copying pasting or whatnot. I'll use the proper repository for next issue.