### PR TITLE
Ensuring to load spreadsheet for each component in a game after mounting the component card. This ensures the numbers are correct for the component cards. Fixes #4

### DIFF
--- a/lib/components/component/ComponentCard.vue
+++ b/lib/components/component/ComponentCard.vue
@@ -27,6 +27,12 @@ v-flex.component(sm10 :elevation-10="isActiveComponent()" :class="{ active: isAc
       }
     },
 
+    mounted() {
+      if(this.component.spreadsheetId) {
+        this.ensureSheetIndexed(this.component.spreadsheetId)
+      }
+    },
+
     data() {
       return {
         showDeleteDialog: false
@@ -46,7 +52,7 @@ v-flex.component(sm10 :elevation-10="isActiveComponent()" :class="{ active: isAc
     },
 
     methods: {
-      ...mapActions(["destroyGameComponent"]),
+      ...mapActions(["destroyGameComponent", "ensureSheetIndexed"]),
 
       setActive() {
         if(this.isActiveComponent()) { return }


### PR DESCRIPTION
Ensuring to load spreadsheet for each component in a game after mounting the component card. This ensures the numbers are correct for the component cards