### PR TITLE
Fixes #issue16. Adding a new stretch mode for image layers that would distort the image to occupy exactly the box size.

### DIFF
--- a/lib/components/template/layer/ImageLayerEditor.vue
+++ b/lib/components/template/layer/ImageLayerEditor.vue
@@ -33,6 +33,7 @@ v-expansion-panel#image-layer-editor(popout)
             v-radio-group(label="Scaling:" v-model="imageScaling" row)
               v-radio(color="primary" label="Fit" value="fitToBox")
               v-radio(color="primary" label="Fill" value="fillToBox")
+              v-radio(color="primary" label="Stretch" value="stretch")
 
         p Horizontal:
         magic-property-input-talker(:layer="layer" attributeName="horizontalAlignment")

--- a/lib/services/pdf_renderer/image_renderer.js
+++ b/lib/services/pdf_renderer/image_renderer.js
@@ -123,6 +123,15 @@ const imageBox = function(doc, image, boxDimensions, options) {
       finalW,
       finalH
     )
+    // We just stretch the image to the size of the box
+  } else if(options.scaleMode == "stretch") {
+    doc.addImage(
+      image,
+      boxDimensions.x,
+      boxDimensions.y,
+      boxDimensions.w,
+      boxDimensions.h
+    )
   }
 }
 


### PR DESCRIPTION
Basically, adding a new stretch mode for the image layer. It distorts the image (in case the size is not exactly as the box) to fit it exactly to the box size.

Stretch:
<img width="932" alt="stretch" src="https://user-images.githubusercontent.com/4833422/73712667-ad650c80-46bf-11ea-8bff-8c5f6c684a41.png">

Fill:
<img width="936" alt="fill" src="https://user-images.githubusercontent.com/4833422/73712672-b229c080-46bf-11ea-891d-67a0510b85e1.png">

Fit:
<img width="945" alt="fit" src="https://user-images.githubusercontent.com/4833422/73712677-b950ce80-46bf-11ea-8c57-b86f84861889.png">

