### PR TITLE
Fixes #issue8. Allowing a setting to merge same-size components, to save paper.

### DIFF
--- a/lib/components/print/PrintSettings.vue
+++ b/lib/components/print/PrintSettings.vue
@@ -52,6 +52,12 @@ v-card
 
       v-checkbox(label="Enable Spacing?" v-model="componentSpacing")
 
+      v-label
+        strong Merge same size components
+      v-divider
+        p If you want to print same size components in the same page instead of starting a new one.
+      v-checkbox(label="Merge components?" v-model="componentMerging")
+
 
       //- Margins
       v-label
@@ -163,6 +169,16 @@ v-card
 
         set(componentSpacing) {
           this.updatePrintSettings({ componentSpacing })
+        }
+      },
+
+      componentMerging: {
+        get() {
+          return this.getPrintSettings.componentMerging
+        },
+
+        set(componentMerging) {
+          this.updatePrintSettings({ componentMerging })
         }
       },
 

--- a/lib/services/pdf_renderer/layout.js
+++ b/lib/services/pdf_renderer/layout.js
@@ -30,8 +30,13 @@ export function autoLayoutItems(doc, componentSizes, printSettings) {
       h: (pageSize.h - totalVerticalMargin)
     }
 
-  // Group components by size
-  componentSizes = flatten(values(groupBy(componentSizes, ({ size }) => `${size.w}x${size.h}`)))
+  if(printSettings.componentMerging) {
+    // Group components by size
+    componentSizes =
+      flatten(
+        values(
+          groupBy(componentSizes, ({ size }) => `${size.w}x${size.h}`)))
+  }
 
   let
     lastW = 0,

--- a/lib/services/pdf_renderer/layout.js
+++ b/lib/services/pdf_renderer/layout.js
@@ -78,8 +78,10 @@ export function autoLayoutItems(doc, componentSizes, printSettings) {
         // the component fits into the print medium
         // lay it out in rows and columns
 
-        // If we enabled component merging, or it's a different size component, we start a new page
-        if (!printSettings.componentMerging || (lastH !== size.h && lastW !== size.w)) {
+        // Do we start this component on a new page, or do will it merge with the last one?
+        // if component merging is disabled or either dimension is different
+        if (!printSettings.componentMerging || (lastW !== size.w || lastH !== size.h)) {
+          // Start a new page!
           lastX = 0
           lastY = 0
           currentPage += 1

--- a/lib/services/pdf_renderer/layout.js
+++ b/lib/services/pdf_renderer/layout.js
@@ -30,13 +30,17 @@ export function autoLayoutItems(doc, componentSizes, printSettings) {
       h: (pageSize.h - totalVerticalMargin)
     }
 
+  // We sort the componentSizes by size, to make it easier to reuse the same page,
+  // even for different components, when using the componentMerging setting
+  componentSizes = [...componentSizes].sort((a, b) => (a.size.w - b.size.w) - (a.size.h - b.size.h))
+
   let
+    lastW = 0,
+    lastH = 0,
     lastX = 0,
     lastY = 0,
     currentPage = 0,
     itemLocations = componentSizes.reduce((locations, { size, name, quantity }) => {
-      lastX = 0
-      lastY = 0
 
       // make sure there's a slot for this kind of component
       locations[name] = locations[name] || []
@@ -74,9 +78,14 @@ export function autoLayoutItems(doc, componentSizes, printSettings) {
         // the component fits into the print medium
         // lay it out in rows and columns
 
-        // new page on new component
-        // TODO: "component mingling" print setting, for the paper-conscious
-        currentPage += 1
+        // If we enabled component merging, or it's a different size component, we start a new page
+        if (!printSettings.componentMerging || (lastH !== size.h && lastW !== size.w)) {
+          lastX = 0
+          lastY = 0
+          currentPage += 1
+        }
+        lastW = size.w
+        lastH = size.h
 
         // TODO: look up spacer settings
         const spacer = printSettings.componentSpacing ? COMPONENT_SPACING_AMOUNT : 0

--- a/lib/services/pdf_renderer/layout.js
+++ b/lib/services/pdf_renderer/layout.js
@@ -1,4 +1,4 @@
-import { times } from 'lodash'
+import { flatten, reduce, times, values } from 'lodash'
 import { MODE_AUTO_LAYOUT, MODE_COMPONENT_PER_PAGE } from '../../store/print'
 import { startEmptyDocument } from './document'
 
@@ -30,9 +30,20 @@ export function autoLayoutItems(doc, componentSizes, printSettings) {
       h: (pageSize.h - totalVerticalMargin)
     }
 
-  // We sort the componentSizes by size, to make it easier to reuse the same page,
-  // even for different components, when using the componentMerging setting
-  componentSizes = [...componentSizes].sort((a, b) => (a.size.w - b.size.w) - (a.size.h - b.size.h))
+  // Sort components into buckets based on their dimensions
+  let componentSizeMap = reduce(componentSizes, (sizeMap, component) => {
+    // Keying on the size like: "5x25"
+    const key = `${component.size.w}x${component.size.h}`
+    // Default the collection at that key
+    sizeMap[key] = sizeMap[key] || []
+    // Add to the collection at that key
+    sizeMap[key].push(component)
+    // Always return the accumulator
+    return sizeMap
+  }, {})
+
+  // Dump all the buckets back into one array
+  componentSizes = flatten(values(componentSizeMap))
 
   let
     lastW = 0,

--- a/lib/services/pdf_renderer/layout.js
+++ b/lib/services/pdf_renderer/layout.js
@@ -1,4 +1,4 @@
-import { flatten, reduce, times, values } from 'lodash'
+import { flatten, groupBy, times, values } from 'lodash'
 import { MODE_AUTO_LAYOUT, MODE_COMPONENT_PER_PAGE } from '../../store/print'
 import { startEmptyDocument } from './document'
 
@@ -30,20 +30,8 @@ export function autoLayoutItems(doc, componentSizes, printSettings) {
       h: (pageSize.h - totalVerticalMargin)
     }
 
-  // Sort components into buckets based on their dimensions
-  let componentSizeMap = reduce(componentSizes, (sizeMap, component) => {
-    // Keying on the size like: "5x25"
-    const key = `${component.size.w}x${component.size.h}`
-    // Default the collection at that key
-    sizeMap[key] = sizeMap[key] || []
-    // Add to the collection at that key
-    sizeMap[key].push(component)
-    // Always return the accumulator
-    return sizeMap
-  }, {})
-
-  // Dump all the buckets back into one array
-  componentSizes = flatten(values(componentSizeMap))
+  // Group components by size
+  componentSizes = flatten(values(groupBy(componentSizes, ({ size }) => `${size.w}x${size.h}`)))
 
   let
     lastW = 0,

--- a/lib/store/print.js
+++ b/lib/store/print.js
@@ -33,6 +33,7 @@ const PrintModule = {
     customWidth: 8.3,
     customHeight: 11,
     componentSpacing: false,
+    componentMerging: false,
     marginTop: DEFAULT_MARGIN,
     marginRight: DEFAULT_MARGIN,
     marginBottom: DEFAULT_MARGIN,


### PR DESCRIPTION
Basically, I created a new setting that can be enabled from the print settings menu, to merge components in the same page if they're of the same size. To do that, I sorted the componentSizes in the auto-layout mode, so it's easier to determine that we don't need to start a new page. Feel free to change any nomenclature, etc... Also, I know about using complete names for variables, but in this case for a compare function I thought it kind of makes sense to stick to abstract variables, but feel free to correct me!