### PR TITLE
Paperize.io: Now with Parentheses !

### DIFF
--- a/lib/services/pdf_renderer/text_renderer.js
+++ b/lib/services/pdf_renderer/text_renderer.js
@@ -62,7 +62,8 @@ export default {
     let fontSize = doc.internal.getFontSize(),
       finalX = layerDimensions.x + alignmentOffsetX,
       finalY,
-      splitText
+      splitText, //split text to size
+      cleanText  //clean text for compatibility
 
     // Shrink-to-Fit: detect when text is too wide or tall for the box and
     // back off the font size until it fits, or we hit the minimum size
@@ -107,8 +108,22 @@ export default {
         fontSize -= 1
         doc.setFontSize(fontSize)
       }
-    }
+    }   
+    
+    // Clean text
+    // Quick and dirty fix until PNG renderer is complete
 
-    doc.text(splitText, finalX, finalY, { align: horizontalAlignment })
+    // Note: This does need to be done after the text has been split,
+    // otherwise doc.splitTextToSize() will return incorrect values
+    // due to the additional characters
+    cleanText = []
+    for(var i = 0; i < splitText.length; i ++) {    
+      cleanText[i] = splitText[i].replace(/\\/g, '\\\\') // Escape '\'
+      cleanText[i] = cleanText[i].replace(/\(/g, '\\(' ) // Escape '('
+      cleanText[i] = cleanText[i].replace(/\)/g, '\\)' ) // Escape ')'
+    }
+    // I would love to do this smarter ^, but I didn't want to take the time to figure out a more clever regex
+
+    doc.text(cleanText, finalX, finalY, { align: horizontalAlignment })
   }
 }

--- a/lib/services/pdf_renderer/text_renderer.js
+++ b/lib/services/pdf_renderer/text_renderer.js
@@ -114,15 +114,13 @@ export default {
     // Quick and dirty fix until PNG renderer is complete
 
     // Note: This does need to be done after the text has been split,
-    // otherwise doc.splitTextToSize() will return incorrect values
+    // otherwise doc.splitTextToSize() will break at incorrect intervals
     // due to the additional characters
-    cleanText = map(splitText, (x) => {
-      x = x.replace(/\\/g, '\\\\') // Escape '\'
-      x = x.replace(/\(/g, '\\(' ) // Escape '('
-      x = x.replace(/\)/g, '\\)' ) // Escape ')'
-      return x
+    cleanText = map(splitText, (lineOfText) => {
+      return lineOfText.replace(/\\|\(|\)/g, (specialCharacter) => {
+        return '\\' + specialCharacter;
+      })
     })
-    // I would love to do this smarter ^, but I didn't want to take the time to figure out a more clever regex   
 
     doc.text(cleanText, finalX, finalY, { align: horizontalAlignment })
   }

--- a/lib/services/pdf_renderer/text_renderer.js
+++ b/lib/services/pdf_renderer/text_renderer.js
@@ -1,4 +1,4 @@
-import { includes, reduce } from 'lodash'
+import { includes, map, reduce } from 'lodash'
 import mustache from '../../services/tiny-mustache'
 
 const PTS_PER_INCH = 72,
@@ -116,13 +116,13 @@ export default {
     // Note: This does need to be done after the text has been split,
     // otherwise doc.splitTextToSize() will return incorrect values
     // due to the additional characters
-    cleanText = []
-    for(var i = 0; i < splitText.length; i ++) {    
-      cleanText[i] = splitText[i].replace(/\\/g, '\\\\') // Escape '\'
-      cleanText[i] = cleanText[i].replace(/\(/g, '\\(' ) // Escape '('
-      cleanText[i] = cleanText[i].replace(/\)/g, '\\)' ) // Escape ')'
-    }
-    // I would love to do this smarter ^, but I didn't want to take the time to figure out a more clever regex
+    cleanText = map(splitText, (x) => {
+      x = x.replace(/\\/g, '\\\\') // Escape '\'
+      x = x.replace(/\(/g, '\\(' ) // Escape '('
+      x = x.replace(/\)/g, '\\)' ) // Escape ')'
+      return x
+    })
+    // I would love to do this smarter ^, but I didn't want to take the time to figure out a more clever regex   
 
     doc.text(cleanText, finalX, finalY, { align: horizontalAlignment })
   }

--- a/lib/services/pdf_renderer/text_renderer.js
+++ b/lib/services/pdf_renderer/text_renderer.js
@@ -3,7 +3,8 @@ import mustache from '../../services/tiny-mustache'
 
 const PTS_PER_INCH = 72,
   LINE_HEIGHT = 1.2,
-  MIN_FONT_SIZE = 4
+  MIN_FONT_SIZE = 4,
+  SPECIAL_CHARACTERS = /\\|\(|\)/g;
 
 export default {
   render(doc, layer, layerDimensions, item, index, total) {
@@ -117,7 +118,7 @@ export default {
     // otherwise doc.splitTextToSize() will break at incorrect intervals
     // due to the additional characters
     cleanText = map(splitText, (lineOfText) => {
-      return lineOfText.replace(/\\|\(|\)/g, (specialCharacter) => {
+      return lineOfText.replace(SPECIAL_CHARACTERS, (specialCharacter) => {
         return '\\' + specialCharacter;
       })
     })


### PR DESCRIPTION
A quick and dirty fix to clean text before being rendered by jsPDF.

Special characters like `\` `(` and `)` are escaped before being rendered by jsPDF.
At first, I tried sanitizing the text before passing it through `doc.splitTextToSize()`, but the additional characters meant that line breaks did not appear where they were supposed to. Ultimately it required iterating over each element in the `splitText` array and sanitizing it.

There are a couple of improvements off the top of my head.
1. The additional `cleanText` array is somewhat superfluous. It would be easy to just assign the clean text to the original array, but I thought maybe this was more readable.
2. The cleaning itself is fairly hardcoded so there isn't an easily configurable way to add more special characters.
3. There are multiple calls to `string.replace()` that could probably be cut down with a more creative regex