### PR TITLE
Fixes #88. Not showing the dimensions editor if we still don't have the template from the new active layer (since committing to the template the new layer might take longer).

### DIFF
--- a/lib/components/template/layer/DimensionEditor.vue
+++ b/lib/components/template/layer/DimensionEditor.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 v-expansion-panel-content#dimension-editor
   div(slot="header") Dimensions
-  v-card
+  v-card(v-if="size")
     v-card-text
       v-layout(column)
           v-flex

--- a/lib/components/template/layer/ImageLayerEditor.vue
+++ b/lib/components/template/layer/ImageLayerEditor.vue
@@ -93,8 +93,8 @@ v-expansion-panel#image-layer-editor(popout)
       dimensions() { return this.getLayerDimensions(this.layer) },
 
       templateSize() {
-        let template = this.findTemplateByLayerId(this.layer.id)
-        return template ? template.size : template
+        const template = this.findTemplateByLayerId(this.layer.id)
+        return template && template.size
       },
 
       ...computedVModelUpdateAll("layer", "patchLayer", [

--- a/lib/components/template/layer/ImageLayerEditor.vue
+++ b/lib/components/template/layer/ImageLayerEditor.vue
@@ -93,7 +93,8 @@ v-expansion-panel#image-layer-editor(popout)
       dimensions() { return this.getLayerDimensions(this.layer) },
 
       templateSize() {
-        return this.findTemplateByLayerId(this.layer.id).size
+        let template = this.findTemplateByLayerId(this.layer.id)
+        return template ? template.size : template
       },
 
       ...computedVModelUpdateAll("layer", "patchLayer", [

--- a/lib/components/template/layer/ShapeLayerEditor.vue
+++ b/lib/components/template/layer/ShapeLayerEditor.vue
@@ -84,8 +84,8 @@ v-expansion-panel#shape-layer-editor(popout)
       dimensions() { return this.getLayerDimensions(this.layer) },
 
       templateSize() {
-        let template = this.findTemplateByLayerId(this.layer.id)
-        return template ? template.size : template
+        const template = this.findTemplateByLayerId(this.layer.id)
+        return template && template.size
       },
 
       ...computedVModelUpdateAll("layer", "patchLayer", [

--- a/lib/components/template/layer/ShapeLayerEditor.vue
+++ b/lib/components/template/layer/ShapeLayerEditor.vue
@@ -1,4 +1,5 @@
 <template lang="pug">
+
 v-expansion-panel#shape-layer-editor(popout)
   name-editor(:layer="layer")
 
@@ -83,7 +84,8 @@ v-expansion-panel#shape-layer-editor(popout)
       dimensions() { return this.getLayerDimensions(this.layer) },
 
       templateSize() {
-        return this.findTemplateByLayerId(this.layer.id).size
+        let template = this.findTemplateByLayerId(this.layer.id)
+        return template ? template.size : template
       },
 
       ...computedVModelUpdateAll("layer", "patchLayer", [

--- a/lib/components/template/layer/TextLayerEditor.vue
+++ b/lib/components/template/layer/TextLayerEditor.vue
@@ -86,7 +86,8 @@ v-expansion-panel#text-layer-editor(popout)
       dimensions() { return this.getLayerDimensions(this.layer) },
 
       templateSize() {
-        return this.findTemplateByLayerId(this.layer.id).size
+        let template = this.findTemplateByLayerId(this.layer.id)
+        return template ? template.size : template
       },
 
       availableFontStyles() {

--- a/lib/components/template/layer/TextLayerEditor.vue
+++ b/lib/components/template/layer/TextLayerEditor.vue
@@ -86,8 +86,8 @@ v-expansion-panel#text-layer-editor(popout)
       dimensions() { return this.getLayerDimensions(this.layer) },
 
       templateSize() {
-        let template = this.findTemplateByLayerId(this.layer.id)
-        return template ? template.size : template
+        const template = this.findTemplateByLayerId(this.layer.id)
+        return template && template.size
       },
 
       availableFontStyles() {


### PR DESCRIPTION
Not showing the dimensions editor if we still don't have the template from the new active layer (since committing to the template the new layer might take longer).