### PR TITLE
Add justify horizontal alignment option.

### DIFF
--- a/lib/components/template/layer/TextLayerEditor.vue
+++ b/lib/components/template/layer/TextLayerEditor.vue
@@ -34,6 +34,7 @@ v-expansion-panel#text-layer-editor(popout)
           v-btn(small flat value="left") Left
           v-btn(small flat value="center") Center
           v-btn(small flat value="right") Right
+          v-btn(small flat value="justify") Justify
 
         p Vertical Alignment
         magic-property-input-talker(:layer="layer" attributeName="verticalAlignment")

--- a/lib/models/text_layer.js
+++ b/lib/models/text_layer.js
@@ -4,7 +4,7 @@ import { validateBoolean, validateEqual, validateIncluded, validateColor,
 export const TEXT_TYPE = 'text'
 
 export const VERTICAL_ALIGNMENTS = [ "top", "middle", "bottom" ]
-export const HORIZONTAL_ALIGNMENTS = [ "left", "center", "right" ]
+export const HORIZONTAL_ALIGNMENTS = [ "left", "center", "right", "justify" ]
 
 export const DEFAULT_TEXT_LAYER = {
   name:                "[Text]",

--- a/lib/services/pdf_renderer/text_renderer.js
+++ b/lib/services/pdf_renderer/text_renderer.js
@@ -126,6 +126,6 @@ export default {
       })
     })
 
-    doc.text(cleanText, finalX, finalY, { align: horizontalAlignment })
+    doc.text(cleanText, finalX, finalY, { align: horizontalAlignment, maxWidth: layerDimensions.w })
   }
 }


### PR DESCRIPTION
This was mostly a plug-and-play sort of change.  jsPDF already supported justified text.  

Only gotcha was that the width of the layer has to be supplied when rendering the text, otherwise it defaults to the full width of the document.  This doesn't appear to be an issue for other alignment types because all that extra space is always blank, but for justify it was spreading the words out a ton to take up the extra space.  

The change is safe for the other types of alignment as well - they don't need the extra blank space, it just wasn't causing problems.